### PR TITLE
Increase Bamboo respawn limit

### DIFF
--- a/templates/default/upstart.erb
+++ b/templates/default/upstart.erb
@@ -6,7 +6,7 @@ start on runlevel [2345]
 stop on [!12345]
 
 respawn
-respawn limit 2 5
+respawn limit 10 5
 
 umask 007
 


### PR DESCRIPTION
The 2 times every 5 seconds limit was too low for Bamboo to restart in
some cases.
