### PR TITLE
Add the ability to configure the 'bind' flag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@ default['qubit_bamboo']['version'] = '0.2.14'
 default['qubit_bamboo']['syslog']  = true
 
 default['qubit_bamboo']['flags']['config'] = "#{node['qubit_bamboo']['home']}/production.json"
+default['qubit_bamboo']['flags']['bind'] = ':8000'
 
 default['qubit_bamboo']['config']['Marathon']['Endpoint'] = 'http://localhost:8080'
 


### PR DESCRIPTION
`:8000` is the default value (in use if no flag provided)
